### PR TITLE
Tuple Version Updated

### DIFF
--- a/IntelliSenseExtender/IntelliSenseExtender.csproj
+++ b/IntelliSenseExtender/IntelliSenseExtender.csproj
@@ -329,8 +329,8 @@
     <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Threading.Tasks.Extensions.4.5.1\lib\portable-net45+win8+wp8+wpa81\System.Threading.Tasks.Extensions.dll</HintPath>
     </Reference>
-    <Reference Include="System.ValueTuple, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.ValueTuple.4.4.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+    <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.ValueTuple.4.5.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
     </Reference>
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />

--- a/IntelliSenseExtender/packages.config
+++ b/IntelliSenseExtender/packages.config
@@ -95,7 +95,7 @@
   <package id="System.Threading.Tasks.Extensions" version="4.5.1" targetFramework="net46" />
   <package id="System.Threading.Tasks.Parallel" version="4.3.0" targetFramework="net46" />
   <package id="System.Threading.Thread" version="4.3.0" targetFramework="net46" />
-  <package id="System.ValueTuple" version="4.4.0" targetFramework="net46" />
+  <package id="System.ValueTuple" version="4.5.0" targetFramework="net46" />
   <package id="System.Xml.ReaderWriter" version="4.3.0" targetFramework="net46" />
   <package id="System.Xml.XDocument" version="4.3.0" targetFramework="net46" />
   <package id="System.Xml.XmlDocument" version="4.3.0" targetFramework="net46" />


### PR DESCRIPTION
VS 2017 15.8.4 was crashing. Updating the Tuple reference to latest,4.5.0, fixed the crash.